### PR TITLE
Automatic database creation and drop 

### DIFF
--- a/pytest_sqlalchemy.py
+++ b/pytest_sqlalchemy.py
@@ -27,6 +27,11 @@ def engine(request, sqlalchemy_connect_url, app_config):
     else:
         raise RuntimeError("Can not establish a connection to the database")
 
+    # Put a suffix like _gw0, _gw1 etc on xdist processes
+    xdist_suffix = getattr(request.config, 'slaveinput', {}).get('slaveid')
+    if engine.url.database != ':memory:' and xdist_suffix is not None:
+        engine.url.database = '{}_{}'.format(engine.url.database, xdist_suffix)
+
     def fin():
         print ("Disposing engine")
         engine.dispose()

--- a/pytest_sqlalchemy.py
+++ b/pytest_sqlalchemy.py
@@ -41,7 +41,7 @@ def engine(request, sqlalchemy_connect_url, app_config):
 
 
 @pytest.fixture(scope="session")
-def db_schema(request, engine, sqlalchemy_keep_db):
+def db_schema(request, engine, sqlalchemy_manage_db, sqlalchemy_keep_db):
     if not sqlalchemy_manage_db:
         return
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ setup(
     url='http://github.com/toirl/pytest-sqlalchemy/',
     py_modules=['pytest_sqlalchemy'],
     entry_points={'pytest11': ['sqlalchemy = pytest_sqlalchemy']},
-    install_requires=['pytest>=2.0', 'sqlalchemy'],
+    install_requires=['pytest>=2.0', 'sqlalchemy', 'SQLAlchemy-Utils'],
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Topic :: Software Development :: Testing',


### PR DESCRIPTION
`pytest-sqlalchemy` always assumes database it is configured to run against is present and ready.

This might not always be the case. It may be cleaner to recreate entire database each time test suite is run.

This pull request adds such a functionality using [sqlalchemy-utils](https://github.com/kvesteri/sqlalchemy-utils) library.

Another nice feature is to have support for `pytest-xdist` just like `pytest-django` has. It was added, so it is now possible to run tests against multiple dynamically created databases.

