### PR TITLE
Fix behaviour under multiprocessing by recreating Engine instance

### DIFF
--- a/pytest_sqlalchemy.py
+++ b/pytest_sqlalchemy.py
@@ -31,6 +31,7 @@ def engine(request, sqlalchemy_connect_url, app_config):
     xdist_suffix = getattr(request.config, 'slaveinput', {}).get('slaveid')
     if engine.url.database != ':memory:' and xdist_suffix is not None:
         engine.url.database = '{}_{}'.format(engine.url.database, xdist_suffix)
+        engine = create_engine(engine.url)  # override engine
 
     def fin():
         print ("Disposing engine")


### PR DESCRIPTION
Unfortunately it turned out that overriding engine's URL is not enough to change name of database used.

To get proper behaviour `Engine` instance is recreated once we know we are dealing with multiprocess test execution (xdist).