### PR TITLE
Show alternative method to define database URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,10 @@ def test_connection(connection):
 You need to provide the connection URL for the engine when invoking the pytest command::
 
     pytest --sqlalchemy-connect-url="postgresql://scott:tiger@localhost:5432/mydatabase"
+    
+Or override the `sqlalchemy_connect_url` fixture on your conftest file:
+
+    @pytest.fixture()
+    def sqlalchemy_connect_url():
+        return 'postgresql://scott:tiger@localhost:5432/mydatabase'
+


### PR DESCRIPTION
Show an alternative method for defining database URI on the README file, 
since probably many users do not want to set the URI through the command line.